### PR TITLE
Fixed non-working JSON/Rust implementation

### DIFF
--- a/lib/src/loggingeventprocessor.cpp
+++ b/lib/src/loggingeventprocessor.cpp
@@ -1,6 +1,9 @@
 #include "loggingeventprocessor.h"
 
-#include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logEventProcessor)
+Q_LOGGING_CATEGORY(logEventProcessor, "hollyphant.event.processor")
 
 using namespace qmlext::event;
 
@@ -18,7 +21,7 @@ public:
 
     void operator()(const Event &event, const QVariant &key, const QVariant &value) const
     {
-        qDebug() << "Sending event" << static_cast<int>(event.type()) << key << value;
+        qCDebug(logEventProcessor) << "Sending event" << static_cast<int>(event.type()) << key << value;
         m_publisher(event, key, value);
     }
 
@@ -35,7 +38,7 @@ LoggingEventProcessor::LoggingEventProcessor(std::unique_ptr<EventProcessor> und
 
 void LoggingEventProcessor::execute(EventPublisher eventPublisher, const QVariant &key, const QVariant &args)
 {
-    qDebug() << "Execute requested" << key << args;
+    qDebug(logEventProcessor) << "Execute requested" << key << args;
     auto loggingPublisher = LoggingEventPublisher(std::move(eventPublisher));
     m_underlying->execute(std::move(loggingPublisher), key, args);
 }

--- a/lib/src/rust/main.cpp
+++ b/lib/src/rust/main.cpp
@@ -26,7 +26,6 @@ public:
     }
     void execute(EventPublisher eventPublisher, QByteArray key, QByteArray args) override
     {
-        qDebug() << "Execute requested" << key << args;
         auto rustPublisherImpl = std::make_unique<RustEventPublisherImpl>(eventPublisher);
         m_processor->execute(std::make_unique<RustEventPublisher>(std::move(rustPublisherImpl)), key.toStdString(),
                              args.toStdString());


### PR DESCRIPTION
The fix is mostly in libqmlext, that was not supporting JSON format from QJSValue.

Also improved logging.