### PR TITLE
Fixes for Mastodon account creation UI

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_target(otherfiles SOURCES
     qml/accounts/NewAccountBskyDialog.qml
     qml/accounts/NewAccountDialog.qml
     qml/accounts/NewAccountMasAuthDialog.qml
-    qml/accounts/NewAccountMasAuthFinalizationPage.qml
+    qml/accounts/NewAccountMasAuthFinalizationDialog.qml
     qml/components/ErrorItem.qml
     qml/components/StatusDisplay.qml
     qml/cover/CoverPage.qml

--- a/bin/qml/accounts/NewAccountMasAuthDialog.qml
+++ b/bin/qml/accounts/NewAccountMasAuthDialog.qml
@@ -68,7 +68,6 @@ Dialog {
                         id: codeField
                         label: qsTr("Login code")
                         placeholderText: qsTr("Login code")
-                        inputMethodHints: Qt.ImhDigitsOnly
                         focus: true
 
                         EnterKey.iconSource: "image://theme/icon-m-enter-accept"
@@ -99,6 +98,6 @@ Dialog {
 
     Component {
         id: finalizationPage
-        NewAccountMasAuthFinalizationPage {}
+        NewAccountMasAuthFinalizationDialog {}
     }
 }

--- a/bin/qml/accounts/NewAccountMasAuthFinalizationDialog.qml
+++ b/bin/qml/accounts/NewAccountMasAuthFinalizationDialog.qml
@@ -3,7 +3,7 @@ import Sailfish.Silica 1.0
 import harbour.hollyphant 1.0
 import "../components"
 
-Page {
+Dialog {
     id: container
     function load() {
         var args = {
@@ -12,6 +12,20 @@ Page {
         }
         loginItem.execute(args)
     }
+
+    function _handleAccept() {
+        if (loginStatus.status === StatusItem.Success
+                && status == DialogStatus.Opened) {
+            canAccept = true
+            accept()
+        }
+    }
+
+    canAccept: false
+    acceptDestination: accountsPage
+    acceptDestinationAction: PageStackAction.Pop
+
+    onStatusChanged: _handleAccept()
 
     BusyLabel {
         text: "Logging into Mastodon"
@@ -29,7 +43,7 @@ Page {
             anchors.right: parent.right
             spacing: Theme.paddingMedium
 
-            PageHeader {
+            DialogHeader {
                 title: qsTr("New Mastodon account")
             }
 
@@ -41,6 +55,7 @@ Page {
 
     StatusItem {
         id: loginStatus
+        onStatusChanged: container._handleAccept()
         item: ValueItem {
             id: loginItem
             eventBus: EventBus
@@ -48,11 +63,6 @@ Page {
                 "context": "new-account",
                 "service": "mastodon",
                 "action": "login"
-            }
-        }
-        onStatusChanged: {
-            if (status === StatusItem.Success) {
-                pageStack.pop(accountsPage)
             }
         }
     }

--- a/bin/qml/components/ErrorItem.qml
+++ b/bin/qml/components/ErrorItem.qml
@@ -10,8 +10,8 @@ Column {
     spacing: Theme.paddingLarge
 
     Icon {
-        anchors.centerIn: parent
-        source: "image://icon-l-attention"
+        anchors.horizontalCenter: parent.horizontalCenter
+        source: "image://theme/icon-l-attention"
     }
 
     Label {


### PR DESCRIPTION
- Revert back to alphanum keyboard for code
- Fixed error icon
- Made sure that the account finalization dialog works (it used not to work if finalization was too fast)